### PR TITLE
Asscalar to item

### DIFF
--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -1645,8 +1645,8 @@ class RegularlySampledAnalogSignalArray:
             if medians.size == 1:
                 try:
                     return np.asscalar(medians)
-                except ValueError:
-                    return np.ndarray.item(medians)
+                except AttributeError:
+                    return medians.item()
             return medians
         except IndexError:
             raise IndexError(
@@ -1660,8 +1660,8 @@ class RegularlySampledAnalogSignalArray:
             if means.size == 1:
                 try:
                     return np.asscalar(means)
-                except ValueError:
-                    return np.ndarray.item(means)
+                except AttributeError:
+                    return means.item()
             return means
         except IndexError:
             raise IndexError(
@@ -1675,8 +1675,8 @@ class RegularlySampledAnalogSignalArray:
             if stds.size == 1:
                 try:
                     return np.asscalar(stds)
-                except ValueError:
-                    return np.ndarray.item(stds)
+                except AttributeError:
+                    return stds.item()
             return stds
         except IndexError:
             raise IndexError(
@@ -1690,8 +1690,8 @@ class RegularlySampledAnalogSignalArray:
             if maxes.size == 1:
                 try:
                     return np.asscalar(maxes)
-                except ValueError:
-                    return np.ndarray.item(maxes)
+                except AttributeError:
+                    return maxes.item()
             return maxes
         except ValueError:
             raise ValueError(
@@ -1705,8 +1705,8 @@ class RegularlySampledAnalogSignalArray:
             if mins.size == 1:
                 try:
                     return np.asscalar(mins)
-                except ValueError:
-                    return np.ndarray.item(mins)
+                except AttributeError:
+                    return mins.item()
             return mins
         except ValueError:
             raise ValueError(

--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -1643,10 +1643,7 @@ class RegularlySampledAnalogSignalArray:
         try:
             medians = np.nanmedian(self.data, axis=axis).squeeze()
             if medians.size == 1:
-                try:
-                    return np.asscalar(medians)
-                except AttributeError:
-                    return medians.item()
+                return medians.item()
             return medians
         except IndexError:
             raise IndexError(
@@ -1658,10 +1655,7 @@ class RegularlySampledAnalogSignalArray:
         try:
             means = np.nanmean(self.data, axis=axis).squeeze()
             if means.size == 1:
-                try:
-                    return np.asscalar(means)
-                except AttributeError:
-                    return means.item()
+                return means.item()
             return means
         except IndexError:
             raise IndexError(
@@ -1673,10 +1667,7 @@ class RegularlySampledAnalogSignalArray:
         try:
             stds = np.nanstd(self.data, axis=axis).squeeze()
             if stds.size == 1:
-                try:
-                    return np.asscalar(stds)
-                except AttributeError:
-                    return stds.item()
+                return stds.item()
             return stds
         except IndexError:
             raise IndexError(
@@ -1688,10 +1679,7 @@ class RegularlySampledAnalogSignalArray:
         try:
             maxes = np.amax(self.data, axis=axis).squeeze()
             if maxes.size == 1:
-                try:
-                    return np.asscalar(maxes)
-                except AttributeError:
-                    return maxes.item()
+                return maxes.item()
             return maxes
         except ValueError:
             raise ValueError(
@@ -1703,10 +1691,7 @@ class RegularlySampledAnalogSignalArray:
         try:
             mins = np.amin(self.data, axis=axis).squeeze()
             if mins.size == 1:
-                try:
-                    return np.asscalar(mins)
-                except AttributeError:
-                    return mins.item()
+                return mins.item()
             return mins
         except ValueError:
             raise ValueError(

--- a/nelpy/core/_eventarray.py
+++ b/nelpy/core/_eventarray.py
@@ -1307,7 +1307,7 @@ class BinnedEventArray(BaseEventArray):
         try:
             medians = np.nanmedian(self.data, axis=axis).squeeze()
             if medians.size == 1:
-                return np.asscalar(medians)
+                return medians.item()
             return medians
         except IndexError:
             raise IndexError("Empty BinnedEventArray; cannot calculate median.")
@@ -1317,7 +1317,7 @@ class BinnedEventArray(BaseEventArray):
         try:
             means = np.nanmean(self.data, axis=axis).squeeze()
             if means.size == 1:
-                return np.asscalar(means)
+                return means.item()
             return means
         except IndexError:
             raise IndexError("Empty BinnedEventArray; cannot calculate mean.")
@@ -1327,7 +1327,7 @@ class BinnedEventArray(BaseEventArray):
         try:
             stds = np.nanstd(self.data, axis=axis).squeeze()
             if stds.size == 1:
-                return np.asscalar(stds)
+                return stds.item()
             return stds
         except IndexError:
             raise IndexError(

--- a/nelpy/decoding.py
+++ b/nelpy/decoding.py
@@ -623,7 +623,7 @@ class Cumhist(np.ndarray):
         )
         try:
             vals = np.asscalar(f(*val))
-        except ValueError:
+        except AttributeError:
             vals = f(*val)
 
         return vals

--- a/nelpy/decoding.py
+++ b/nelpy/decoding.py
@@ -622,7 +622,7 @@ class Cumhist(np.ndarray):
             x=self, y=self._bincenters, kind="linear", fill_value=np.NaN
         )
         try:
-            vals = np.asscalar(f(*val))
+            vals = f(*val).item()
         except AttributeError:
             vals = f(*val)
 

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     download_url = 'https://github.com/nelpy/nelpy/tarball/' + main_ns['__version__'],
     license='MIT License',
     author='Etienne Ackermann',
-    install_requires=['numpy>=1.11.0', # 1.11 introduced axis keyword in np.gradient
+    install_requires=['numpy>=1.16.0', # 1.11 introduced axis keyword in np.gradient
                     'scipy>=0.18.0', # 0.17.0 introduced functionality we use for interp1d, 0.18.0 introduced next_fast_len()
                     'matplotlib>=1.5.0', # 1.4.3 doesn't support the step kwarg in rasterc yet
                     'dill', # so that we can pickle lambda functions

--- a/tests/test_AnalogSignalArray.py
+++ b/tests/test_AnalogSignalArray.py
@@ -1,10 +1,11 @@
-import nelpy as nel
-import numpy as np
 from math import pi
+
+import numpy as np
+
+import nelpy as nel
 
 
 class TestRegularlySampledAnalogSignalArray:
-
     def test_copy(self):
         data = np.arange(100)
         fs = 10
@@ -141,9 +142,20 @@ class TestRegularlySampledAnalogSignalArray:
             means == np.array([np.array([1.5, 7.5, 3.5]), np.array([4.5, 9.5, 5.5])])
         ).all()
 
+    def test_asa_dim_mean1(self):
+        x = [[1, 2, 4, 5], [7, 8, 9, 10]]
+        asa = nel.AnalogSignalArray(x)
+        assert np.array(asa.mean(axis=0) == np.mean(x, axis=0)).all()
+        assert np.array(asa.mean(axis=1) == np.mean(x, axis=1)).all()
+
+    def test_asa_dim_mean2(self):
+        x = [[1, 2, 3, 4, 5]]
+        asa = nel.AnalogSignalArray(x)
+        assert np.array(asa.mean(axis=0) == np.mean(x, axis=0)).all()
+        assert np.array(asa.mean(axis=1) == np.mean(x, axis=1)).all()
+
 
 class TestHalfOpenIntervals:
-
     def test_asa_halfopen_1(self):
         asa = nel.AnalogSignalArray([0, 1, 2, 3, 4, 5, 6])
         assert asa.n_samples == 7

--- a/tests/test_EventArray.py
+++ b/tests/test_EventArray.py
@@ -1,12 +1,11 @@
+import numpy as np
+
 import nelpy as nel
 from nelpy.utils import ragged_array
-import numpy as np
 
 
 class TestEventArray:
-
     def test_copy(self):
-
         abscissa_vals = np.array([[2, 3, 4, 5], [11, 12, 13, 14]])
         fs = 2
         series_labels = ["a", "b"]
@@ -34,7 +33,6 @@ class TestEventArray:
 
 
 class TestBinnedEventArray:
-
     def test_copy(self):
         abscissa_vals = np.array([[2, 3, 4, 5], [11, 12, 13, 14]])
         fs = 2
@@ -65,9 +63,7 @@ class TestBinnedEventArray:
 
 
 class TestSpikeTrainArray:
-
     def test_construct(self):
-
         fs = 1
         series_ids = [21]
         series_labels = ["pyr"]
@@ -97,7 +93,6 @@ class TestSpikeTrainArray:
         assert sta.n_series == 1
 
     def test_indexing(self):
-
         sta = nel.SpikeTrainArray(
             [
                 [1, 2, 3, 4, 5, 6, 7, 8, 9.5, 10, 10.5, 11.4, 15, 18, 19, 20, 21],
@@ -120,7 +115,6 @@ class TestSpikeTrainArray:
         assert sta_indexed._desc == sta._desc
 
     def test_empty(self):
-
         sta = nel.SpikeTrainArray(
             [[3, 4, 5, 6, 7], [2, 4, 5]], support=nel.EpochArray([0, 8]), fs=1
         )
@@ -145,7 +139,6 @@ class TestSpikeTrainArray:
         assert sta1.support.isempty
 
     def test_copy_without_data(self):
-
         sta = nel.SpikeTrainArray(
             [[3, 4, 5, 6, 7], [2, 4, 5]], support=nel.EpochArray([0, 8]), fs=1
         )
@@ -161,9 +154,7 @@ class TestSpikeTrainArray:
 
 
 class TestBinnedSpikeTrainArray:
-
     def test_construct_with_sta(self):
-
         fs = 1
         series_ids = [21]
         series_labels = ["pyr"]
@@ -204,7 +195,6 @@ class TestBinnedSpikeTrainArray:
         assert bst.n_series == 1
 
     def test_indexing_1(self):
-
         bst = nel.SpikeTrainArray(
             [
                 [1, 2, 3, 4, 5, 6, 7, 8, 9.5, 10, 10.5, 11.4, 15, 18, 19, 20, 21],
@@ -241,7 +231,6 @@ class TestBinnedSpikeTrainArray:
         assert bst_indexed._desc == bst._desc
 
     def test_indexing_2(self):
-
         # support indexing by list
         bst = nel.SpikeTrainArray(
             [1, 2, 3, 4, 5, 6, 7, 8, 9.5, 10, 10.5, 11.4, 15, 18, 19, 20, 21],
@@ -259,7 +248,6 @@ class TestBinnedSpikeTrainArray:
         assert bst.n_intervals == 3
 
     def test_empty(self):
-
         bst = nel.SpikeTrainArray(
             [[3, 4, 5, 6, 7], [2, 4, 5]], support=nel.EpochArray([0, 8]), fs=1
         ).bin(ds=1)
@@ -289,7 +277,6 @@ class TestBinnedSpikeTrainArray:
         assert bst1.support.isempty
 
     def copy_without_data(self):
-
         bst = nel.SpikeTrainArray(
             [[3, 4, 5, 6, 7], [2, 4, 5]], support=nel.EpochArray([0, 8]), fs=1
         ).bin(ds=1)
@@ -304,9 +291,30 @@ class TestBinnedSpikeTrainArray:
         assert bst.isempty
         assert bst.eventarray.isempty
 
+    def test_bst_mean1(self):
+        bst = nel.SpikeTrainArray(
+            [[3, 4, 5, 6, 7], [2, 4, 5]], support=nel.EpochArray([0, 8]), fs=1
+        ).bin(ds=1)
+
+        assert np.array(bst.mean() == np.array([0.625, 0.375])).all()
+        assert np.array(
+            bst.mean(axis=0) == np.array([0.0, 0.0, 0.5, 0.5, 1.0, 1.0, 0.5, 0.5])
+        ).all()
+        assert np.array(bst.mean(axis=1) == np.array([0.625, 0.375])).all()
+
+    def test_bst_mean2(self):
+        bst = nel.SpikeTrainArray(
+            [[3, 4, 5, 6, 7]], support=nel.EpochArray([0, 8]), fs=1
+        ).bin(ds=1)
+
+        assert np.array(bst.mean() == 0.625).all()
+        assert np.array(
+            bst.mean(axis=0) == np.array([0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 1.0])
+        ).all()
+        assert np.array(bst.mean(axis=1) == 0.625).all()
+
 
 class TestSpikeTrainArrayEtienne:
-
     def test_1(self):
         sta = nel.SpikeTrainArray([[], [], []])
         assert sta.n_units == 3  # failed before updates


### PR DESCRIPTION
numpy asscalar deprecated since version 1.16, using .item()