### PR TITLE
Reduce noisy support/fs logging and avoid confusing internal fs deprecation warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,35 @@ If you would like to modify the code, then replace the last command with
 
 A weak prerequisite for installing nelpy is a modified version of [hmmlearn](https://github.com/eackermann/hmmlearn/tree/master/hmmlearn). This requirement is weak, in the sense that installation will complete successfully without it, and most of nelpy can also be used without any problems. However, as soon as any of the hidden Markov model (HMM) functions are used, you will get an error if the correct version of ``hmmlearn`` is not installed. To make things easier, there is a handy 64-bit Windows wheel in the [hmmlearn directory](https://github.com/nelpy/nelpy/blob/master/hmmlearn/) of this repository. Installation on Linux/Unix should be almost trivial.
 
+Controlling log verbosity
+=========================
+
+When restricting objects to support/epochs, nelpy may emit informational log
+messages such as "ignoring signal outside of support".
+
+By default, Python logging usually shows ``WARNING`` and above, so ``INFO``
+messages are hidden unless explicitly enabled.
+
+To reduce nelpy-only log noise without muting other libraries, set the ``nelpy``
+logger to ``ERROR`` (or ``WARNING``):
+
+```python
+import logging
+
+logging.basicConfig()
+logging.getLogger("nelpy").setLevel(logging.ERROR)
+```
+
+To inspect routine nelpy diagnostics while debugging, enable ``INFO`` for the
+``nelpy`` logger:
+
+```python
+import logging
+
+logging.basicConfig(level=logging.INFO)
+logging.getLogger("nelpy").setLevel(logging.INFO)
+```
+
 Related work and inspiration
 ============================
 Nelpy drew heavy inspiration from the ``python-vdmlab`` package (renamed to ``nept``)

--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -611,7 +611,7 @@ class RegularlySampledAnalogSignalArray:
             self._restrict_to_interval_array_fast(intervalarray=support)
         else:
             logger.info(
-                "creating support from abscissa_vals and sampling rate, fs!"
+                "creating support from abscissa_vals and step (inferred when not provided)."
             )
             self._abscissa.support = type(self._abscissa.support)(
                 utils.get_contiguous_segments(

--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -28,6 +28,8 @@ from scipy.stats import zscore
 from .. import core, filtering, utils, version
 from ..utils_.decorators import keyword_deprecation, keyword_equivalence
 
+logger = logging.getLogger(__name__)
+
 
 class IntervalSignalSlicer(object):
     """
@@ -1246,7 +1248,7 @@ class RegularlySampledAnalogSignalArray:
             indices.append((frm, to))
         indices = np.array(indices, ndmin=2)
         if np.diff(indices).sum() < len(self._abscissa_vals):
-            logging.warning("ignoring signal outside of support")
+            logger.info("ignoring signal outside of support")
         # check if only one interval and interval is already bounds of data
         # if so, we don't need to do anything
         if len(indices) == 1:
@@ -1317,7 +1319,7 @@ class RegularlySampledAnalogSignalArray:
             )
         indices = np.any(np.column_stack(indices), axis=1)
         if np.count_nonzero(indices) < len(self._abscissa_vals):
-            logging.warning("ignoring signal outside of support")
+            logger.info("ignoring signal outside of support")
         try:
             self._data = self.data[:, indices]
         except IndexError:

--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -342,11 +342,11 @@ def rsasa_init_wrapper(func):
             abscissa_vals = abscissa_vals[:-1]
         else:
             if re_estimate_fs:
-                logging.warning(
+                logger.info(
                     "fs was not specified, so we try to estimate it from the data..."
                 )
                 fs = 1.0 / np.median(np.diff(abscissa_vals))
-                logging.warning("fs was estimated to be {} Hz".format(fs))
+                logger.info("fs was estimated to be {} Hz".format(fs))
             else:
                 if no_fs:
                     logging.warning(
@@ -610,12 +610,12 @@ class RegularlySampledAnalogSignalArray:
         if support is not None:
             self._restrict_to_interval_array_fast(intervalarray=support)
         else:
-            logging.warning(
+            logger.info(
                 "creating support from abscissa_vals and sampling rate, fs!"
             )
             self._abscissa.support = type(self._abscissa.support)(
                 utils.get_contiguous_segments(
-                    self._abscissa_vals, step=self._step, fs=fs, in_core=in_core
+                    self._abscissa_vals, step=self._step, in_core=in_core
                 )
             )
             if merge_sample_gap > 0:

--- a/nelpy/core/_eventarray.py
+++ b/nelpy/core/_eventarray.py
@@ -28,6 +28,8 @@ from .. import core, utils, version
 from ..utils_.decorators import keyword_deprecation, keyword_equivalence
 from . import _accessors
 
+logger = logging.getLogger(__name__)
+
 __all__ = ["EventArray", "BinnedEventArray", "SpikeTrainArray", "BinnedSpikeTrainArray"]
 
 
@@ -828,7 +830,7 @@ class EventArray(BaseEventArray):
                     data = utils.ragged_array(data_)
             self._data = data
             if issue_warning:
-                logging.warning("ignoring events outside of eventarray support")
+                logger.info("ignoring events outside of eventarray support")
 
         self._abscissa.support = newintervals
         return self

--- a/nelpy/utils.py
+++ b/nelpy/utils.py
@@ -1188,7 +1188,7 @@ def get_contiguous_segments(
         logging.warning("'sort' has been deprecated; use 'assume_sorted' instead")
     if fs:
         step = 1 / fs
-        logger.info("'fs' has been deprecated; use 'step' instead")
+        logger.warning("'fs' has been deprecated; use 'step' instead")
 
     if inclusive:
         assert index, "option 'inclusive' can only be used with 'index=True'"

--- a/nelpy/utils.py
+++ b/nelpy/utils.py
@@ -31,6 +31,8 @@ from scipy.signal import hilbert
 from . import core  # so that core.RegularlySampledAnalogSignalArray is exposed
 from .utils_.decorators import keyword_deprecation
 
+logger = logging.getLogger(__name__)
+
 try:
     from scipy.fft import next_fast_len  # scipy 1.*
 except ImportError:
@@ -1186,7 +1188,7 @@ def get_contiguous_segments(
         logging.warning("'sort' has been deprecated; use 'assume_sorted' instead")
     if fs:
         step = 1 / fs
-        logging.warning("'fs' has been deprecated; use 'step' instead")
+        logger.info("'fs' has been deprecated; use 'step' instead")
 
     if inclusive:
         assert index, "option 'inclusive' can only be used with 'index=True'"
@@ -1205,7 +1207,7 @@ def get_contiguous_segments(
         # that t1 = t and t2 = t + 2/fs, i.e. a difference of 2 steps.
 
         if np.any(np.diff(data) < step):
-            logging.warning(
+            logger.info(
                 "some steps in the data are smaller than the requested step size."
             )
 

--- a/tests/test_logging_filtering.py
+++ b/tests/test_logging_filtering.py
@@ -89,7 +89,20 @@ def test_asa_init_does_not_emit_fs_deprecated_message(caplog):
     assert "'fs' has been deprecated; use 'step' instead" not in messages
 
 
-def test_get_contiguous_segments_fs_and_step_messages_are_info(caplog):
+def test_asa_init_support_creation_message_is_info(caplog):
+    with caplog.at_level(logging.INFO, logger="nelpy"):
+        _ = nel.AnalogSignalArray(data=[0, 1, 2, 3], abscissa_vals=[0, 0.25, 0.5, 0.75], fs=4)
+
+    records = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "creating support from abscissa_vals and step (inferred when not provided)."
+    ]
+    assert records
+    assert all(rec.levelno == logging.INFO for rec in records)
+
+
+def test_get_contiguous_segments_fs_deprecation_warns_and_step_message_is_info(caplog):
     with caplog.at_level(logging.INFO, logger="nelpy"):
         _ = utils.get_contiguous_segments([0.0, 0.2, 0.4], fs=5)
         _ = utils.get_contiguous_segments([0.0, 0.2, 0.4], step=0.5)
@@ -105,4 +118,5 @@ def test_get_contiguous_segments_fs_and_step_messages_are_info(caplog):
 
     assert fs_deprecated
     assert step_small
-    assert all(rec.levelno == logging.INFO for rec in fs_deprecated + step_small)
+    assert all(rec.levelno == logging.WARNING for rec in fs_deprecated)
+    assert all(rec.levelno == logging.INFO for rec in step_small)

--- a/tests/test_logging_filtering.py
+++ b/tests/test_logging_filtering.py
@@ -1,6 +1,7 @@
 import logging
 
 import nelpy as nel
+from nelpy import utils
 
 
 def test_eventarray_support_clipping_logs_info(caplog):
@@ -60,3 +61,48 @@ def test_nelpy_logger_level_controls_support_clipping_noise(caplog):
         assert not records
     finally:
         nelpy_logger.setLevel(original_level)
+
+
+def test_rsasa_init_estimated_fs_logs_info(caplog):
+    with caplog.at_level(logging.INFO, logger="nelpy"):
+        _ = nel.AnalogSignalArray(data=[0, 1, 2, 3], abscissa_vals=[0, 0.25, 0.5, 0.75])
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert "fs was not specified, so we try to estimate it from the data..." in messages
+    assert any(msg.startswith("fs was estimated to be ") for msg in messages)
+
+    fs_records = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "fs was not specified, so we try to estimate it from the data..."
+        or rec.getMessage().startswith("fs was estimated to be ")
+    ]
+    assert fs_records
+    assert all(rec.levelno == logging.INFO for rec in fs_records)
+
+
+def test_asa_init_does_not_emit_fs_deprecated_message(caplog):
+    with caplog.at_level(logging.INFO, logger="nelpy"):
+        _ = nel.AnalogSignalArray(data=[0, 1, 2, 3], abscissa_vals=[0, 0.25, 0.5, 0.75], fs=4)
+
+    messages = [rec.getMessage() for rec in caplog.records]
+    assert "'fs' has been deprecated; use 'step' instead" not in messages
+
+
+def test_get_contiguous_segments_fs_and_step_messages_are_info(caplog):
+    with caplog.at_level(logging.INFO, logger="nelpy"):
+        _ = utils.get_contiguous_segments([0.0, 0.2, 0.4], fs=5)
+        _ = utils.get_contiguous_segments([0.0, 0.2, 0.4], step=0.5)
+
+    fs_deprecated = [
+        rec for rec in caplog.records if rec.getMessage() == "'fs' has been deprecated; use 'step' instead"
+    ]
+    step_small = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "some steps in the data are smaller than the requested step size."
+    ]
+
+    assert fs_deprecated
+    assert step_small
+    assert all(rec.levelno == logging.INFO for rec in fs_deprecated + step_small)

--- a/tests/test_logging_filtering.py
+++ b/tests/test_logging_filtering.py
@@ -1,0 +1,62 @@
+import logging
+
+import nelpy as nel
+
+
+def test_eventarray_support_clipping_logs_info(caplog):
+    ea = nel.EventArray(
+        abscissa_vals=[[0.1, 0.3, 1.1]],
+        support=nel.EpochArray([0, 2]),
+        fs=1,
+    )
+
+    with caplog.at_level(logging.INFO, logger="nelpy"):
+        _ = ea[nel.EpochArray([0, 1])]
+
+    records = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "ignoring events outside of eventarray support"
+    ]
+    assert records
+    assert all(rec.levelno == logging.INFO for rec in records)
+
+
+def test_analogsignalarray_support_clipping_logs_info(caplog):
+    asa = nel.AnalogSignalArray([0, 1, 2, 3, 4], fs=1)
+
+    with caplog.at_level(logging.INFO, logger="nelpy"):
+        _ = asa[nel.EpochArray([0, 3])]
+
+    records = [
+        rec
+        for rec in caplog.records
+        if rec.getMessage() == "ignoring signal outside of support"
+    ]
+    assert records
+    assert all(rec.levelno == logging.INFO for rec in records)
+
+
+def test_nelpy_logger_level_controls_support_clipping_noise(caplog):
+    ea = nel.EventArray(
+        abscissa_vals=[[0.1, 0.3, 1.1]],
+        support=nel.EpochArray([0, 2]),
+        fs=1,
+    )
+
+    nelpy_logger = logging.getLogger("nelpy")
+    original_level = nelpy_logger.level
+
+    try:
+        nelpy_logger.setLevel(logging.ERROR)
+        with caplog.at_level(logging.INFO):
+            _ = ea[nel.EpochArray([0, 1])]
+
+        records = [
+            rec
+            for rec in caplog.records
+            if rec.getMessage() == "ignoring events outside of eventarray support"
+        ]
+        assert not records
+    finally:
+        nelpy_logger.setLevel(original_level)


### PR DESCRIPTION
This PR reduces warning spam in common support-restriction and ASA initialization workflows while preserving behavior and API semantics.

What changed

Demoted expected clipping/support diagnostics from warning to info in key paths.
Switched those noisy messages to module loggers so they can be filtered at nelpy logger scope.
Updated ASA internal support construction to call get_contiguous_segments with step only, preventing the confusing internal fs deprecation warning.
Kept clipping/restriction behavior unchanged.
Added focused regression tests for logging behavior.

Why
Users reported frequent, noisy messages that are expected during normal workflows, including:

ignoring events/signal outside support
support creation and fs estimation diagnostics
fs deprecation messaging triggered indirectly during ASA construction
Linked issues

Addresses [https://github.com/nelpy/nelpy/issues/299](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Addresses [https://github.com/nelpy/nelpy/issues/76](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Related discussion [https://github.com/nelpy/nelpy/issues/92](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Fixes the confusion described in [https://github.com/nelpy/nelpy/issues/288](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Related discussion: [https://github.com/nelpy/nelpy/issues/282](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
Files touched

[_eventarray.py](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[_analogsignalarray.py](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[utils.py](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)
[test_logging_filtering.py](vscode-file://vscode-app/c:/Users/Cornell/AppData/Local/Programs/Microsoft%20VS%20Code/e7fb5e96c0/resources/app/out/vs/code/electron-browser/workbench/workbench.html)



Notes for reviewers
This is intentionally a minimal, behavior-preserving pass focused on high-noise warnings.
Some warning-level messages remain in place where they are likely actionable (for example genuine input/deprecation cases outside the scoped noisy paths).
