### PR TITLE
make _analogsignalarray nan aware

### DIFF
--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -1953,7 +1953,7 @@ class RegularlySampledAnalogSignalArray:
             Maximum values along the specified axis.
         """
         try:
-            maxes = np.amax(self.data, axis=axis).squeeze()
+            maxes = np.nanmax(self.data, axis=axis).squeeze()
             if maxes.size == 1:
                 return maxes.item()
             return maxes
@@ -1977,7 +1977,7 @@ class RegularlySampledAnalogSignalArray:
             Minimum values along the specified axis.
         """
         try:
-            mins = np.amin(self.data, axis=axis).squeeze()
+            mins = np.nanmin(self.data, axis=axis).squeeze()
             if mins.size == 1:
                 return mins.item()
             return mins

--- a/tests/test_AnalogSignalArray.py
+++ b/tests/test_AnalogSignalArray.py
@@ -308,6 +308,22 @@ def test_rsasa_mean_std_min_max():
     assert np.allclose(asa.data.max(axis=1), asa.max())
 
 
+def test_rsasa_stats_are_nan_aware():
+    data = np.array(
+        [
+            [1.0, np.nan, 3.0, 4.0],
+            [np.nan, 5.0, 6.0, np.nan],
+        ]
+    )
+    abscissa = np.linspace(0, 1, data.shape[1])
+    asa = RegularlySampledAnalogSignalArray(data=data, abscissa_vals=abscissa)
+
+    assert np.allclose(np.nanmean(data, axis=1), asa.mean())
+    assert np.allclose(np.nanstd(data, axis=1), asa.std())
+    assert np.allclose(np.nanmin(data, axis=1), asa.min())
+    assert np.allclose(np.nanmax(data, axis=1), asa.max())
+
+
 def test_rsasa_isempty_edge():
     # Robustly handle empty array construction
     try:


### PR DESCRIPTION
Switched RSASA max to NaN-aware reduction in _analogsignalarray.py:1956 by using np.nanmax. 

Switched RSASA min to NaN-aware reduction in _analogsignalarray.py:1980 by using np.nanmin. 

Added regression test test_AnalogSignalArray.py:311 in test_AnalogSignalArray.py to verify mean/std/min/max all match NumPy NaN-aware behavior on NaN-containing data.