### PR TITLE
Fix pickle rehydration for core objects

### DIFF
--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -651,6 +651,15 @@ class RegularlySampledAnalogSignalArray:
         self._interp = None
         self.__bake__()
 
+    def __setstate__(self, state):
+        """Restore pickled objects and reattach runtime-only helpers."""
+        self.__dict__.update(state)
+        self.__dict__.setdefault("__version__", version.__version__)
+        self.__dict__.setdefault("type_name", self.__class__.__name__)
+        for attr in RegularlySampledAnalogSignalArray.__attributes__:
+            self.__dict__.setdefault(attr, None)
+        self.__renew__()
+
     def __call__(self, x):
         """RegularlySampledAnalogSignalArray callable method. Returns
         interpolated data at requested points. Note that points falling

--- a/nelpy/core/_eventarray.py
+++ b/nelpy/core/_eventarray.py
@@ -175,6 +175,16 @@ class BaseEventArray(ABC):
         self.loc = _accessors.ItemGetterLoc(self)
         self.iloc = _accessors.ItemGetterIloc(self)
 
+    def __setstate__(self, state):
+        """Restore pickled objects and reattach runtime-only helpers."""
+        self.__dict__.update(state)
+        self.__dict__.setdefault("__version__", version.__version__)
+        self.__dict__.setdefault("type_name", self.__class__.__name__)
+        self.__dict__.setdefault("_series_label", "series")
+        for attr in BaseEventArray.__attributes__:
+            self.__dict__.setdefault(attr, None)
+        self.__renew__()
+
     def __repr__(self):
         address_str = " at " + str(hex(id(self)))
         return "<BaseEventArray" + address_str + ">"

--- a/nelpy/core/_intervalarray.py
+++ b/nelpy/core/_intervalarray.py
@@ -170,6 +170,26 @@ class IntervalArray:
         dstr = "of length {}".format(self.formatter(self.length))
         return "<%s%s: %s> %s" % (self.type_name, address_str, nstr, dstr)
 
+    def __setstate__(self, state):
+        """Restore pickled interval arrays with modern display metadata."""
+        self.__dict__.update(state)
+        self.__dict__.setdefault("__version__", version.__version__)
+        self.__dict__.setdefault("type_name", self.__class__.__name__)
+        if isinstance(self, EpochArray):
+            interval_label = "epoch"
+            formatter = formatters.PrettyDuration
+        elif isinstance(self, SpaceArray):
+            interval_label = "interval"
+            formatter = formatters.PrettySpace
+        else:
+            interval_label = "interval"
+            formatter = formatters.ArbitraryFormatter
+        self.__dict__.setdefault("_interval_label", interval_label)
+        self.__dict__.setdefault("formatter", formatter)
+        self.__dict__.setdefault("base_unit", self.formatter.base_unit)
+        for attr in IntervalArray.__attributes__:
+            self.__dict__.setdefault(attr, None)
+
     def __setattr__(self, name, value):
         # https://stackoverflow.com/questions/4017572/how-can-i-make-an-alias-to-a-non-function-member-attribute-in-a-python-class
         name = self.__aliases__.get(name, name)

--- a/nelpy/core/_valeventarray.py
+++ b/nelpy/core/_valeventarray.py
@@ -321,6 +321,16 @@ class BaseValueEventArray(ABC):
         self.loc = ItemGetter_loc(self)
         self.iloc = ItemGetter_iloc(self)
 
+    def __setstate__(self, state):
+        """Restore pickled objects and reattach runtime-only helpers."""
+        self.__dict__.update(state)
+        self.__dict__.setdefault("__version__", version.__version__)
+        self.__dict__.setdefault("type_name", self.__class__.__name__)
+        self.__dict__.setdefault("_series_label", "series")
+        for attr in BaseValueEventArray.__attributes__:
+            self.__dict__.setdefault(attr, None)
+        self.__renew__()
+
     def __repr__(self):
         address_str = " at " + str(hex(id(self)))
         return "<BaseValueEventArray" + address_str + ">"

--- a/tests/test_pickle_compat.py
+++ b/tests/test_pickle_compat.py
@@ -1,6 +1,8 @@
 import dill as pickle
+import pytest
 
 import nelpy as nel
+from nelpy import formatters
 
 
 def _roundtrip_without_attrs(obj, attrs):
@@ -58,3 +60,31 @@ def test_stale_valueeventarray_pickle_reattaches_indexers():
     assert loaded.loc.obj is loaded
     assert loaded.iloc.obj is loaded
     assert loaded.iloc[:, 1].n_series == 1
+
+
+@pytest.mark.parametrize(
+    "obj, formatter, base_unit, interval_label",
+    [
+        (
+            nel.IntervalArray([[0, 1]]),
+            formatters.ArbitraryFormatter,
+            "a.u.",
+            "interval",
+        ),
+        (nel.EpochArray([[0, 1]]), formatters.PrettyDuration, "s", "epoch"),
+        (nel.SpaceArray([[0, 1]]), formatters.PrettySpace, "cm", "interval"),
+    ],
+)
+def test_stale_intervalarray_pickle_restores_display_metadata(
+    obj, formatter, base_unit, interval_label
+):
+    loaded = _roundtrip_without_attrs(
+        obj,
+        ["__version__", "type_name", "_interval_label", "formatter", "base_unit"],
+    )
+
+    assert loaded.__version__ == nel.__version__
+    assert loaded.type_name == loaded.__class__.__name__
+    assert loaded._interval_label == interval_label
+    assert loaded.formatter is formatter
+    assert loaded.base_unit == base_unit

--- a/tests/test_pickle_compat.py
+++ b/tests/test_pickle_compat.py
@@ -1,0 +1,60 @@
+import dill as pickle
+
+import nelpy as nel
+
+
+def _roundtrip_without_attrs(obj, attrs):
+    for attr in attrs:
+        obj.__dict__.pop(attr, None)
+
+    return pickle.loads(pickle.dumps(obj))
+
+
+def test_stale_spiketrainarray_pickle_reattaches_indexers():
+    sta = nel.SpikeTrainArray(
+        [[1, 2, 3, 4], [2, 3, 5]],
+        support=nel.EpochArray([[0, 4], [4, 6]]),
+        fs=1,
+        series_ids=[10, 20],
+    )
+
+    loaded = _roundtrip_without_attrs(sta, ["loc", "iloc"])
+
+    assert loaded.loc.obj is loaded
+    assert loaded.iloc.obj is loaded
+    assert loaded.loc[:, 20].n_series == 1
+    assert loaded.iloc[:, 0].n_series == 1
+
+
+def test_stale_analogsignalarray_pickle_reattaches_slicers():
+    asa = nel.AnalogSignalArray(
+        [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
+        fs=1,
+        support=nel.EpochArray([[0, 2], [3, 5]]),
+    )
+
+    loaded = _roundtrip_without_attrs(
+        asa,
+        ["_intervalsignalslicer", "_intervaldata", "_intervaltime"],
+    )
+
+    assert loaded._intervalsignalslicer.obj is loaded
+    assert loaded._intervaldata._parent is loaded
+    assert loaded._intervaltime._parent is loaded
+    assert loaded[nel.EpochArray([0, 2])].n_signals == 2
+    assert loaded[:, 1].n_signals == 1
+
+
+def test_stale_valueeventarray_pickle_reattaches_indexers():
+    veva = nel.ValueEventArray(
+        events=[[0.1, 0.5], [0.2, 0.6]],
+        values=[[1, 2], [3, 4]],
+        fs=10,
+        series_ids=[3, 4],
+    )
+
+    loaded = _roundtrip_without_attrs(veva, ["loc", "iloc"])
+
+    assert loaded.loc.obj is loaded
+    assert loaded.iloc.obj is loaded
+    assert loaded.iloc[:, 1].n_series == 1

--- a/tests/test_pickle_compat.py
+++ b/tests/test_pickle_compat.py
@@ -1,18 +1,23 @@
-import dill as pickle
+import pickle as stdlib_pickle
+
+import dill
 import pytest
 
 import nelpy as nel
 from nelpy import formatters
 
+SERIALIZERS = [stdlib_pickle, dill]
 
-def _roundtrip_without_attrs(obj, attrs):
+
+def _roundtrip_without_attrs(obj, attrs, serializer):
     for attr in attrs:
         obj.__dict__.pop(attr, None)
 
-    return pickle.loads(pickle.dumps(obj))
+    return serializer.loads(serializer.dumps(obj))
 
 
-def test_stale_spiketrainarray_pickle_reattaches_indexers():
+@pytest.mark.parametrize("serializer", SERIALIZERS)
+def test_stale_spiketrainarray_pickle_reattaches_indexers(serializer):
     sta = nel.SpikeTrainArray(
         [[1, 2, 3, 4], [2, 3, 5]],
         support=nel.EpochArray([[0, 4], [4, 6]]),
@@ -20,7 +25,7 @@ def test_stale_spiketrainarray_pickle_reattaches_indexers():
         series_ids=[10, 20],
     )
 
-    loaded = _roundtrip_without_attrs(sta, ["loc", "iloc"])
+    loaded = _roundtrip_without_attrs(sta, ["loc", "iloc"], serializer)
 
     assert loaded.loc.obj is loaded
     assert loaded.iloc.obj is loaded
@@ -28,7 +33,8 @@ def test_stale_spiketrainarray_pickle_reattaches_indexers():
     assert loaded.iloc[:, 0].n_series == 1
 
 
-def test_stale_analogsignalarray_pickle_reattaches_slicers():
+@pytest.mark.parametrize("serializer", SERIALIZERS)
+def test_stale_analogsignalarray_pickle_reattaches_slicers(serializer):
     asa = nel.AnalogSignalArray(
         [[0, 1, 2, 3, 4], [5, 6, 7, 8, 9]],
         fs=1,
@@ -38,6 +44,7 @@ def test_stale_analogsignalarray_pickle_reattaches_slicers():
     loaded = _roundtrip_without_attrs(
         asa,
         ["_intervalsignalslicer", "_intervaldata", "_intervaltime"],
+        serializer,
     )
 
     assert loaded._intervalsignalslicer.obj is loaded
@@ -47,7 +54,8 @@ def test_stale_analogsignalarray_pickle_reattaches_slicers():
     assert loaded[:, 1].n_signals == 1
 
 
-def test_stale_valueeventarray_pickle_reattaches_indexers():
+@pytest.mark.parametrize("serializer", SERIALIZERS)
+def test_stale_valueeventarray_pickle_reattaches_indexers(serializer):
     veva = nel.ValueEventArray(
         events=[[0.1, 0.5], [0.2, 0.6]],
         values=[[1, 2], [3, 4]],
@@ -55,7 +63,7 @@ def test_stale_valueeventarray_pickle_reattaches_indexers():
         series_ids=[3, 4],
     )
 
-    loaded = _roundtrip_without_attrs(veva, ["loc", "iloc"])
+    loaded = _roundtrip_without_attrs(veva, ["loc", "iloc"], serializer)
 
     assert loaded.loc.obj is loaded
     assert loaded.iloc.obj is loaded
@@ -71,16 +79,28 @@ def test_stale_valueeventarray_pickle_reattaches_indexers():
             "a.u.",
             "interval",
         ),
-        (nel.EpochArray([[0, 1]]), formatters.PrettyDuration, "s", "epoch"),
-        (nel.SpaceArray([[0, 1]]), formatters.PrettySpace, "cm", "interval"),
+        (
+            nel.EpochArray([[0, 1]]),
+            formatters.PrettyDuration,
+            "s",
+            "epoch",
+        ),
+        (
+            nel.SpaceArray([[0, 1]]),
+            formatters.PrettySpace,
+            "cm",
+            "interval",
+        ),
     ],
 )
+@pytest.mark.parametrize("serializer", SERIALIZERS)
 def test_stale_intervalarray_pickle_restores_display_metadata(
-    obj, formatter, base_unit, interval_label
+    obj, formatter, base_unit, interval_label, serializer
 ):
     loaded = _roundtrip_without_attrs(
         obj,
         ["__version__", "type_name", "_interval_label", "formatter", "base_unit"],
+        serializer,
     )
 
     assert loaded.__version__ == nel.__version__


### PR DESCRIPTION
## Summary

Fixes backward compatibility for saved nelpy objects whose pickled state is missing runtime-only helper attributes. Core objects now restore their saved state and reattach transient slicers/indexers during unpickle via `__setstate__`.

## Root Cause

Persistence uses raw dill/pickle, but unpickling bypasses constructors and did not call the existing `__renew__()` methods. Older or stale saved objects could therefore load without helpers such as `loc`, `iloc`, or analog interval slicers, causing indexing/access to fail until users manually repaired the object.

## Changes

- Added object-level `__setstate__` hooks for event arrays, regularly sampled analog arrays, value-event arrays, and interval arrays.
- Backfilled lightweight metadata defaults for old pickles that may be missing newer fields.
- Added regression tests that simulate stale pickles by removing transient attrs before serialization and verifying loaded objects work without manual `__renew__()` calls.

## Validation

- `.conda\python.exe -m pytest tests\test_pickle_compat.py`
- `.conda\python.exe -m pytest tests\test_EventArray.py::TestEventArray::test_copy tests\test_EventArray.py::TestBinnedEventArray::test_copy tests\test_EventArray.py::TestSpikeTrainArray::test_indexing tests\test_AnalogSignalArray.py::TestRegularlySampledAnalogSignalArray::test_copy tests\test_ValueEventArray.py::test_valueeventarray_indexing`
- `.conda\Scripts\ruff.exe check nelpy\core\_eventarray.py nelpy\core\_analogsignalarray.py nelpy\core\_valeventarray.py nelpy\core\_intervalarray.py tests\test_pickle_compat.py`
