### PR TITLE
Fix step-only analog signal construction

### DIFF
--- a/nelpy/core/_analogsignalarray.py
+++ b/nelpy/core/_analogsignalarray.py
@@ -338,8 +338,12 @@ def rsasa_init_wrapper(func):
         else:
             abscissa_vals = kwargs.get("abscissa_vals", None)
         if abscissa_vals is None:
-            abscissa_vals = np.linspace(0, data.shape[1] / fs, data.shape[1] + 1)
-            abscissa_vals = abscissa_vals[:-1]
+            if kwargs.get("step", None) is not None:
+                raise ValueError(
+                    "step cannot be used without abscissa_vals; use fs=1/step "
+                    "to infer regular abscissa values."
+                )
+            abscissa_vals = np.arange(data.shape[1]) / fs
         else:
             if re_estimate_fs:
                 logger.info(
@@ -390,13 +394,11 @@ class RegularlySampledAnalogSignalArray:
         abscissa_vals in seconds, fs in Hz).
         Default is 1 Hz.
     step : float, optional
-        The sampling interval of the data, in seconds.
-        Default is None.
-        specifies step size of samples passed as tdata if fs is given,
-        default is None. If not passed it is inferred by the minimum
-        difference in between samples of tdata passed in (based on if FS
-        is passed). e.g. decimated data would have sample numbers every
-        ten samples so step=10
+        Expected interval between neighboring abscissa values when creating
+        contiguous support from explicitly provided abscissa_vals or tdata.
+        If omitted, the interval is inferred from the provided abscissa values.
+        step is not used to infer default abscissa values; use fs for that
+        purpose.
     merge_sample_gap : float, optional
         Optional merging of gaps between support intervals. If intervals are within
         a certain amount of time, gap, they will be merged as one interval. Example
@@ -2763,7 +2765,11 @@ class AnalogSignalArray(RegularlySampledAnalogSignalArray):
     fs : float, optional
         Sampling frequency in Hz. Default is None.
     step : float, optional
-        Sampling interval in seconds. Default is None.
+        Expected interval between neighboring abscissa values when creating
+        contiguous support from explicitly provided abscissa_vals, time, or
+        timestamps. If omitted, the interval is inferred from the provided
+        abscissa values. step is not used to infer default abscissa values;
+        use fs for that purpose.
     merge_sample_gap : float, optional
         Maximum gap between samples to merge intervals (seconds).
         Default is 0.

--- a/tests/test_AnalogSignalArray.py
+++ b/tests/test_AnalogSignalArray.py
@@ -22,6 +22,29 @@ class TestRegularlySampledAnalogSignalArray:
 
         assert hex(id(copied_rsasa)) == hex(id(copied_rsasa._intervalsignalslicer.obj))
 
+    def test_fs_infers_abscissa_vals(self):
+        data = np.random.RandomState(0).rand(5, 10)
+        asa = nel.AnalogSignalArray(data, fs=2)
+
+        assert np.allclose(asa.abscissa_vals, np.arange(10) / 2)
+
+    def test_step_without_abscissa_vals_raises(self):
+        data = np.random.RandomState(0).rand(5, 10)
+
+        with pytest.raises(ValueError, match="use fs=1/step"):
+            nel.AnalogSignalArray(data, step=0.5)
+
+    def test_step_with_abscissa_vals_controls_support_segments(self):
+        data = np.arange(6)
+        abscissa_vals = np.array([1, 11, 21, 31, 51, 61])
+
+        asa = nel.AnalogSignalArray(
+            data, abscissa_vals=abscissa_vals, fs=30000, step=10
+        )
+
+        assert np.allclose(asa.abscissa_vals, abscissa_vals)
+        assert np.allclose(asa.support.data, np.array([[1, 41], [51, 71]]))
+
     def test_add_signal1D_1(self):
         """Add a signal to an 1D AnalogSignalArray"""
         asa = nel.AnalogSignalArray([1, 2, 4])


### PR DESCRIPTION
## Summary
- Reject `step` when `AnalogSignalArray`/`RegularlySampledAnalogSignalArray` construction would otherwise infer default abscissa values.
- Keep `fs` as the supported way to infer regular abscissa values.
- Preserve legacy `step` behavior for explicitly provided `abscissa_vals`, where it controls contiguous support segmentation.

## Root Cause
`rsasa_init_wrapper` generated default abscissa values from `fs` before the core constructor stored `step`. As a result, `step` appeared accepted but did not define the inferred abscissa values, producing misleading integer-spaced timestamps and fragmented support.

## Validation
- `.\\.conda\\python.exe -m pytest tests/test_AnalogSignalArray.py`
- `.\\.conda\\python.exe -m ruff check nelpy/core/_analogsignalarray.py tests/test_AnalogSignalArray.py`

Fixes #282
